### PR TITLE
changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ SE-Owned/Debug/TeamFortress2.ilk
 *.enc
 SE-Owned/.vs/SE-Owned/v17/.suo
 SE-Owned/Release/sound.wav
+*.bin

--- a/SE-Owned/TeamFortress2/TeamFortress2/DLLMain.cpp
+++ b/SE-Owned/TeamFortress2/TeamFortress2/DLLMain.cpp
@@ -103,16 +103,22 @@ DWORD WINAPI MainThread(LPVOID lpParam)
 
 	while (!GetAsyncKeyState(VK_F11))
 		std::this_thread::sleep_for(std::chrono::milliseconds(420));
+
 	g_Interfaces.Engine->ClientCmd_Unrestricted("play vo/items/wheatley_sapper/wheatley_sapper_hacked02.mp3");
 	g_GlobalInfo.unloadWndProcHook = true;
 	Vars::Visuals::SkyboxChanger.m_Var = false;
-	g_ChatInfo.RemoveListeners();
 	g_Menu.m_bOpen = false;
 	Vars::Visuals::ThirdPerson.m_Var = false;
-	g_Interfaces.CVars->ConsoleColorPrintf({ 255, 255, 0, 255 }, _("Fedoraware Unloaded!\n"));
-	g_Visuals.RestoreWorldModulation(); //needs to do this after hooks are released cuz UpdateWorldMod in FSN will override it
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	
+	g_ChatInfo.RemoveListeners();
 	g_Hooks.Release();
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
 	g_Visuals.RestoreWorldModulation(); //needs to do this after hooks are released cuz UpdateWorldMod in FSN will override it
+	g_Interfaces.CVars->ConsoleColorPrintf({ 255, 255, 0, 255 }, _("Fedoraware Unloaded!\n"));
 
 	WinAPI::FreeLibraryAndExitThread(static_cast<HMODULE>(lpParam), EXIT_SUCCESS);
 	return EXIT_SUCCESS;

--- a/SE-Owned/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
+++ b/SE-Owned/TeamFortress2/TeamFortress2/Features/Aimbot/AimbotHitscan/AimbotHitscan.cpp
@@ -500,6 +500,8 @@ void bulletTracer(CBaseEntity* pLocal, Target_t Target) {
 
 void CAimbotHitscan::Run(CBaseEntity *pLocal, CBaseCombatWeapon *pWeapon, CUserCmd *pCmd)
 {
+	static int nLastTracerTick = pCmd->tick_count;
+
 	if (!Vars::Aimbot::Hitscan::Active.m_Var)
 		return;
 
@@ -594,8 +596,9 @@ void CAimbotHitscan::Run(CBaseEntity *pLocal, CBaseCombatWeapon *pWeapon, CUserC
 
 		if (bIsAttacking) {
 			g_GlobalInfo.m_bAttacking = true;
-			if (Vars::Visuals::BulletTracer.m_Var) {
+			if (Vars::Visuals::BulletTracer.m_Var && abs(pCmd->tick_count - nLastTracerTick) > 1) {
 				bulletTracer(pLocal, Target);
+				nLastTracerTick = pCmd->tick_count;
 			}
 		}
 

--- a/SE-Owned/TeamFortress2/TeamFortress2/Features/ESP/ESP.cpp
+++ b/SE-Owned/TeamFortress2/TeamFortress2/Features/ESP/ESP.cpp
@@ -274,6 +274,7 @@ void CESP::DrawPlayers(CBaseEntity *pLocal)
 						g_Draw.Rect((middle - (wideth / 2)) - 5, y - offset, wideth + 10, heighth + 2, { 0,0,0,180 });
 						//g_Draw.Rect((x + (w / 2) - (wideth / 2)) - 5, y - offset - 7, wideth + 10, 2, LineColor);
 						g_Draw.Rect((middle - (wideth / 2)) - 5, y - offset - 2, wideth + 10, 2, LineColor);
+						offset -= 1;
 					}
 					g_Draw.String(FONT_NAME, middle, (y - offset), DrawColor, ALIGN_CENTERHORIZONTAL, Utils::ConvertUtf8ToWide(pi.name).data());
 				}
@@ -290,6 +291,10 @@ void CESP::DrawPlayers(CBaseEntity *pLocal)
 				if (Vars::ESP::Players::Class.m_Var == 1 || Vars::ESP::Players::Class.m_Var == 3)
 				{
 					int offset = (Vars::ESP::Players::Name.m_Var ? g_Draw.m_vecFonts[FONT_NAME].nTall + (g_Draw.m_vecFonts[FONT_NAME].nTall * 0.3f) : 0);
+
+					if (offset && Vars::ESP::Players::NameBox.m_Var)
+						offset += 2;
+
 					static const int nSize = 18;
 					g_Draw.Texture((x + (w / 2) - (nSize / 2)), ((y - offset) - nSize), nSize, nSize, Colors::White, nClassNum);
 				}

--- a/SE-Owned/TeamFortress2/TeamFortress2/Features/PlayerArrows/PlayerArrows.cpp
+++ b/SE-Owned/TeamFortress2/TeamFortress2/Features/PlayerArrows/PlayerArrows.cpp
@@ -99,7 +99,7 @@ void CPlayerArrows::Run()
 				continue;*/
 
 			Vec3 vAngleToEnemy = Math::CalcAngle(vLocalPos, vEnemyPos);
-			Vec3 viewangless = pLocal->GetEyeAngles();
+			Vec3 viewangless = g_Interfaces.Engine->GetViewAngles();
 			viewangless.x = 0;
 			float fFovToEnemy = Math::CalcFov(viewangless, vAngleToEnemy);
 

--- a/SE-Owned/TeamFortress2/TeamFortress2/Features/What/What.cpp
+++ b/SE-Owned/TeamFortress2/TeamFortress2/Features/What/What.cpp
@@ -539,7 +539,7 @@ void CWhat::Render(IDirect3DDevice9* pDevice) {
 								static const char* ignoreTeammatesEsp[]{ "Off", "All", "Keep friends" }; ImGui::PushItemWidth(100); ImGui::Combo("Ignore teammates###ESPteam", &Vars::ESP::Players::IgnoreTeammates.m_Var, ignoreTeammatesEsp, IM_ARRAYSIZE(ignoreTeammatesEsp)); ImGui::PopItemWidth(); HelpMarker("Which teammates the ESP will ignore drawing on");
 								static const char* ignoreCloakedEsp[]{ "Off", "All", "Enemies only" }; ImGui::PushItemWidth(100); ImGui::Combo("Ignore cloaked###ESPcloak", &Vars::ESP::Players::IgnoreCloaked.m_Var, ignoreCloakedEsp, IM_ARRAYSIZE(ignoreCloakedEsp)); ImGui::PopItemWidth(); HelpMarker("Which cloaked spies the ESP will ignore drawing on");
 								ImGui::Checkbox("Player name", &Vars::ESP::Players::Name.m_Var); HelpMarker("Will draw the players name");
-								ImGui::Checkbox("Name box", &Vars::ESP::Players::Name.m_Var); HelpMarker("Will draw a box around players name to make it stand out");
+								ImGui::Checkbox("Name box", &Vars::ESP::Players::NameBox.m_Var); HelpMarker("Will draw a box around players name to make it stand out");
 								static const char* classEsp[]{ "Off", "Icon", "Text" }; ImGui::PushItemWidth(100); ImGui::Combo("Player class", &Vars::ESP::Players::Class.m_Var, classEsp, IM_ARRAYSIZE(classEsp)); ImGui::PopItemWidth(); HelpMarker("Will draw the class the player is");
 								ImGui::Checkbox("Player health", &Vars::ESP::Players::Health.m_Var); HelpMarker("Will draw the players health, as well as their max health");
 								ImGui::Checkbox("Player health bar", &Vars::ESP::Players::HealthBar.m_Var); HelpMarker("Will draw a bar visualizing how much health the player has");

--- a/SE-Owned/TeamFortress2/TeamFortress2/SDK/Main/BaseCombatWeapon/BaseCombatWeapon.h
+++ b/SE-Owned/TeamFortress2/TeamFortress2/SDK/Main/BaseCombatWeapon/BaseCombatWeapon.h
@@ -132,14 +132,18 @@ public: //Everything else, lol
 			}
 		}
 
-		return (GetNextPrimaryAttack() < pLocal->GetTickBase() * g_Interfaces.GlobalVars->interval_per_tick);
+		float flCurTime = static_cast<float>(pLocal->GetTickBase()) * g_Interfaces.GlobalVars->interval_per_tick;
+
+		return GetNextPrimaryAttack() <= flCurTime && pLocal->GetNextAttack() <= flCurTime;
 	}
 
 	__inline bool CanSecondaryAttack(CBaseEntity* pLocal) {
 		if (!pLocal->IsAlive() || pLocal->IsTaunting() || pLocal->IsBonked() || pLocal->IsAGhost() || pLocal->IsInBumperKart())
 			return false;
 
-		return (GetNextSecondaryAttack() < (static_cast<float>(pLocal->GetTickBase()) * g_Interfaces.GlobalVars->interval_per_tick));
+		float flCurTime = static_cast<float>(pLocal->GetTickBase()) * g_Interfaces.GlobalVars->interval_per_tick;
+
+		return GetNextSecondaryAttack() <= flCurTime && pLocal->GetNextAttack() <= flCurTime;
 	}
 
 	__inline bool IsInReload() {

--- a/SE-Owned/TeamFortress2/TeamFortress2/Utils/SEOHook/SEOHook.h
+++ b/SE-Owned/TeamFortress2/TeamFortress2/Utils/SEOHook/SEOHook.h
@@ -4,6 +4,9 @@
 
 #include "../MinHook/MinHook.h"
 
+#pragma warning (push)
+#pragma warning (disable : 26812) //unscoped enum
+
 namespace SEOHook
 {
 	//PURPOSE: Hooking VFuncs via a Detour
@@ -84,3 +87,5 @@ namespace SEOHook
 		}
 	};
 }
+
+#pragma warning (pop)


### PR DESCRIPTION
made CanShoot & CanSecondaryAttack more accurate
fixed double tracers
made name box in ESP space things more evenly
player arrows now uses engine's viewangles to prevent jitter when using antiaim
proj aim doesn't account for interp now (not needed, probs caused misses too)